### PR TITLE
Refactor Docker setup to use bind mount for SenseBox IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           docker run -d \
           -p 8000:8000 \
+          --mount type=bind,src=${{ github.workspace }}/config,dst=/app/config,ro \
           --name hivebox \
           hivebox:${{ github.sha }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,6 @@ COPY --chmod=u=rwX,go=rX --chown=root:root --from=deps /app/.venv .venv
 # Copy application code
 COPY --chmod=u=rwX,go=rX --chown=root:root src/ src/
 
-# Copy SenseBox IDs config
-COPY --chmod=u=rwX,go=rX --chown=root:root config/sensebox_ids.txt config/
-
 # Set non-root user
 USER appuser
 


### PR DESCRIPTION
- Remove SenseBox IDs config COPY instruction from Dockerfile
- Restore config bind mount to docker run step in CI workflow
- Add ro option to bind mount to be mounted into container as read-only